### PR TITLE
Serde fixes

### DIFF
--- a/enclave/src/contracts/balance.rs
+++ b/enclave/src/contracts/balance.rs
@@ -64,9 +64,7 @@ impl contracts::Contract<Command, Request, Response> for Balance{
                 if let Some(ba) = self.accounts.get(&account) {
                     balance = *ba;
                 }
-                Response::FreeBalance{
-                    balance: balance
-                }
+                Response::FreeBalance { balance }
             },
         }
     }

--- a/enclave/src/contracts/balance.rs
+++ b/enclave/src/contracts/balance.rs
@@ -15,34 +15,25 @@ pub struct Balance{
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub enum Command{
-    Transfer(TransferDetails),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransferDetails{
-    target: AccountIdWrapper,
-    amount: chain::Balance,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum Request{
-    FreeBalance(FreeBalanceReq),
+pub enum Command {
+    Transfer {
+        dest: AccountIdWrapper,
+        #[serde(with = "super::serde_balance")]
+        value: chain::Balance,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct FreeBalanceReq{
-    account: AccountIdWrapper,
+pub enum Request {
+    FreeBalance {
+        account: AccountIdWrapper
+    },
 }
-
 #[derive(Serialize, Deserialize, Debug)]
-pub enum Response{
-    FreeBalance(FreeBalanceResp),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct FreeBalanceResp{
-    balance: chain::Balance,
+pub enum Response {
+    FreeBalance {
+        balance: chain::Balance
+    },
 }
 
 impl Balance{
@@ -58,8 +49,8 @@ impl contracts::Contract<Command, Request, Response> for Balance{
 
     fn handle_command(&mut self, origin: &String, txref: &TxRef, cmd: Command){
         match cmd {
-            Command::Transfer(detail) => {
-                self.accounts.insert(detail.clone().target, detail.amount);
+            Command::Transfer {dest, value} => {
+                self.accounts.insert(dest, value);
             }
         }
     }
@@ -68,12 +59,14 @@ impl contracts::Contract<Command, Request, Response> for Balance{
         // todo: should validate user id first.
 
         match req {
-            Request::FreeBalance(fbreq) => {
+            Request::FreeBalance {account} => {
                 let mut balance: chain::Balance = 0;
-                if let Some(ba) = self.accounts.get(&fbreq.account) {
+                if let Some(ba) = self.accounts.get(&account) {
                     balance = *ba;
                 }
-                Response::FreeBalance(FreeBalanceResp{ balance,})
+                Response::FreeBalance{
+                    balance: balance
+                }
             },
         }
     }
@@ -96,7 +89,8 @@ impl Serialize for AccountIdWrapper{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer,
     {
-        serializer.serialize_bytes(self.0.as_ref())
+        let data_hex = crate::hex::encode_hex_compact(self.0.as_ref());
+        serializer.serialize_str(&data_hex)
     }
 }
 
@@ -120,10 +114,12 @@ impl<'de> Visitor<'de> for AcidVisitor{
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
         where E: de::Error,
     {
-        if v.len() == 32 {
-            Ok(AccountIdWrapper::from(v))
+        let value_str = str::from_utf8(&v).map_err(|_| E::custom("Invalid utf8 string"))?;
+        if v.len() == 64 {
+            let bytes = crate::hex::decode_hex(value_str);  // TODO: error handling
+            Ok(AccountIdWrapper::from(&bytes))
         } else {
-            Err(E::custom(format!("AccountId bytes length wrong: {}", str::from_utf8(&v).unwrap())))
+            Err(E::custom(format!("AccountId bytes length wrong: {}", value_str)))
         }
     }
 }

--- a/enclave/src/contracts/data_plaza.rs
+++ b/enclave/src/contracts/data_plaza.rs
@@ -37,7 +37,7 @@ pub struct ItemDetails {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PricePolicy {
   PerRow {
-    #[serde(serialize_with = "se_to_str", deserialize_with = "de_from_str")]
+    #[serde(with = "super::serde_balance")]
     price: chain::Balance
   },
 }
@@ -67,20 +67,6 @@ pub struct OrderState {
   result_ready: bool,
   matched_rows: u32,
   result_path: String,
-}
-
-// deesr
-
-fn se_to_str<S>(value: &chain::Balance, serializer: S) -> Result<S::Ok, S::Error>
-where S: Serializer {
-  let s = value.to_string();
-  String::serialize(&s, serializer)
-}
-
-fn de_from_str<'de, D>(deserializer: D) -> Result<chain::Balance, D::Error>
-where D: Deserializer<'de> {
-    let s = String::deserialize(deserializer)?;
-    chain::Balance::from_str(&s).map_err(de::Error::custom)
 }
 
 // contract

--- a/enclave/src/contracts/mod.rs
+++ b/enclave/src/contracts/mod.rs
@@ -11,10 +11,6 @@ pub mod balance;
 pub type ContractId = u32;
 pub const DATA_PLAZA: ContractId = 1;
 pub const BALANCE: ContractId = 2;
-/*pub enum ContractId{
-  DataPlaza,
-  Balance,
-}*/
 
 pub trait Contract<Cmd, QReq, QResp>: Serialize + DeserializeOwned + Debug
 where
@@ -25,4 +21,21 @@ where
   fn id(&self) -> ContractId;
   fn handle_command(&mut self, origin: &String, txref: &TxRef, cmd: Cmd);
   fn handle_query(&mut self, req: QReq) -> QResp;
+}
+
+pub mod serde_balance {
+  use crate::std::string::{String, ToString};
+  use crate::std::str::FromStr;
+  use serde::{de, Serialize, Deserialize, Serializer, Deserializer};
+
+  pub fn serialize<S>(value: &chain::Balance, serializer: S) -> Result<S::Ok, S::Error>
+  where S: Serializer {
+    let s = value.to_string();
+    String::serialize(&s, serializer)
+  }
+  pub fn deserialize<'de, D>(deserializer: D) -> Result<chain::Balance, D::Error>
+  where D: Deserializer<'de> {
+      let s = String::deserialize(deserializer)?;
+      chain::Balance::from_str(&s).map_err(de::Error::custom)
+  }
 }

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -986,6 +986,8 @@ fn handle_execution(state: &mut RuntimeState, pos: &TxRef,
     let addr = &origin.unwrap().0;
     let origin = format_address(&addr);
 
+    println!("handle_execution: incominng cmd: {}", String::from_utf8_lossy(&inner_data));
+
     println!("handle_execution: about to call handle_command");
     match contract_id {
         DATA_PLAZA => state.contract1.handle_command(


### PR DESCRIPTION
Fix serde for uint128 & [u8;32] fields.

- Ser/de uint128 as string instead of number. Otherwise it
  produces nonstandard json.
- Ser/de [u8;32] as hex string instead of raw bytes.
- Simplify struct defs in balance.rs